### PR TITLE
pdns-recursor: update to 4.8.0

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=4.7.4
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=4.8.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=17b5c7c881e3f400bb3b527dd866e5cf2cd62d5d33566b1b70b58c608d9968d5
+PKG_HASH:=ccb9017a1a788e95e948e7b240ef8db53ae8a507b915f260188ef343f7f68bdc
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only

--- a/net/pdns-recursor/patches/100-disable-recursor.conf-dist.patch
+++ b/net/pdns-recursor/patches/100-disable-recursor.conf-dist.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -492,12 +492,6 @@ $(srcdir)/effective_tld_names.dat:
+@@ -503,12 +503,6 @@ $(srcdir)/effective_tld_names.dat:
  pubsuffix.cc: $(srcdir)/effective_tld_names.dat
  	$(AM_V_GEN)./mkpubsuffixcc
  
@@ -8,7 +8,7 @@
 -sysconf_DATA = recursor.conf-dist
 -
 -recursor.conf-dist: pdns_recursor
--	$(AM_V_GEN)./pdns_recursor --config > $@
+-	$(AM_V_GEN)./pdns_recursor --config=default > $@
 -
  ## Manpages
  MANPAGES=pdns_recursor.1 \


### PR DESCRIPTION
Signed-off-by: Peter van Dijk <peter.van.dijk@powerdns.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
