### PR TITLE
pdns-recursor: update to 5.0.4, fixes CVE-2024-25583

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=5.0.3
+PKG_VERSION:=5.0.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=01d170a2850eb2aca501d6838a3444136589980d5cb2c2b53392b76459e38c07
+PKG_HASH:=d52aab108a0ad9e8be1de2179a693bb85e995c6a4d958a50702dcf79eec8ef28
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>, Remi Gacogne <remi.gacogne@powerdns.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
