### PR TITLE
[23.05] pdns-recursor: update to 4.9.9

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=4.8.8
+PKG_VERSION:=4.9.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=d25c0a1689027b055e7fd6b20b6aaeadf866f67c68a2112f756d70c13e94dee4
+PKG_HASH:=cda5c7d077b90bd3ef9d6989e9bcf824609a32201093961e62eb6e40c3ef7a48
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>
 PKG_LICENCE:=GPL-2.0-only

--- a/net/pdns-recursor/patches/100-disable-recursor.conf-dist.patch
+++ b/net/pdns-recursor/patches/100-disable-recursor.conf-dist.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -503,12 +503,6 @@ $(srcdir)/effective_tld_names.dat:
+@@ -508,12 +508,6 @@ $(srcdir)/effective_tld_names.dat:
  pubsuffix.cc: $(srcdir)/effective_tld_names.dat
  	$(AM_V_GEN)./mkpubsuffixcc
  


### PR DESCRIPTION
fixes CVE-2024-25590

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
