### PR TITLE
[24.10] dnsdist: update to 1.9.10

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsdist
-PKG_VERSION:=1.9.9
+PKG_VERSION:=1.9.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=e86bc636d4d2dc8bac180ec8cdafbfe5f35229b6005ec15d7510fb6f58b49f5a
+PKG_HASH:=027ddbdee695c5a59728057bfc41c5b1a691fa1c7a5e89278b09f355325fbed6
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>, Remi Gacogne <remi.gacogne@powerdns.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
fixes CVE-2025-30193

**Package details**

    Maintainer: @\<github-user> (find it by checking the history of the package Makefile)
    Description:

**Indication of run testing**

     OpenWrt version:
     OpenWrt target/subtarget:
     OpenWrt device:

**Formalities**

     [ ] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

     If your PR contains a patch
     [ ] Make sure that it can be applied by `git am`
     [ ] It must be refreshed to avoid offsets, fuzzes, etc by `make package/foo/refresh V=s`
     [ ] It must be in a way that it is potentially upstreamable (subject, commit description, etc.), and we must try to upstream it so we have fewer patches and fewer.
