### PR TITLE
pdns-recursor: security update to 5.3.1

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -28,4 +28,4 @@ jobs:
   build:
     name: Feeds Package Test Build
     needs: formalities
-    uses: openwrt/actions-shared-workflows/.github/workflows/multi-arch-test-build.yml@main
+    uses: powerdns/openwrt-actions-shared-workflows/.github/workflows/multi-arch-test-build.yml@diskspace

--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=5.2.5
+PKG_VERSION:=5.3.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=a8a657a7abd6e9d237cdd26753f7dcf5ccd5b8c48ac8120b08d2b8d57a1d856a
+PKG_HASH:=a7b633d4b5da3b5f14d51a78e21e17f1334c828ce96fcccdd97cd7aaaf14cbd5
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>, Remi Gacogne <remi.gacogne@powerdns.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/net/pdns-recursor/patches/100-disable-recursor.yml-dist.patch
+++ b/net/pdns-recursor/patches/100-disable-recursor.yml-dist.patch
@@ -1,14 +1,14 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -563,12 +563,6 @@ $(srcdir)/effective_tld_names.dat:
- pubsuffix.cc: $(srcdir)/effective_tld_names.dat
- 	$(srcdir)/mkpubsuffixcc $< $@
+@@ -565,12 +565,6 @@ dnslabeltext.cc: dnslabeltext.rl
+ pubsuffix.cc:
+ 	$(srcdir)/mkpubsuffixcc $@
  
 -## Config file
 -sysconf_DATA = recursor.yml-dist
 -
 -recursor.yml-dist: pdns_recursor
--	dir=$$(mktemp -d) && touch "$$dir/recursor.yml" && ./pdns_recursor --config-dir="$$dir" --config=default 2> /dev/null > $@ && rm "$$dir/recursor.yml" && rmdir "$$dir"
+-	./pdns_recursor --config=default 2> /dev/null > $@
 -
  ## Manpages
  MANPAGES=pdns_recursor.1 \


### PR DESCRIPTION
fixes CVE-2025-59023,CVE-2025-59024

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
